### PR TITLE
fix: scan error handling — retry, emit results, JSONL output, deadlock fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 venv
+.remember/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Go CLI tool for unauthenticated enumeration of AWS IAM Role ARNs. It probes whether specific IAM role ARNs exist in target AWS accounts by abusing resource policy validation on AWS services (SNS, SQS, S3, ECR Public, S3 Access Points). Each service acts as a "plugin" — it creates a resource, sets a policy referencing a candidate principal ARN, and checks whether AWS accepts or rejects the principal.
+
+This tool is part of the larger `saas-map` project (see parent directory's CLAUDE.md) and provides the scanning engine that discovers which SaaS provider roles exist in a given AWS account.
+
+## Commands
+
+```bash
+make build                    # Build for darwin-arm64 and linux-arm64 into build/
+go test ./...                 # Run all tests
+go test ./pkg/scanner/        # Run scanner tests
+go test ./pkg/plugins/        # Run plugin tests
+go test -run TestName ./pkg/  # Run a single test
+```
+
+### Running the scanner
+
+```bash
+./build/darwin-arm/roles -profile <aws-profile> -setup                    # One-time setup (creates probe resources)
+./build/darwin-arm/roles -profile <aws-profile> -account-list accounts.list -roles roles.list  # Scan
+./build/darwin-arm/roles -json -profile <aws-profile> -account-list accounts.list -roles roles.list  # JSONL output
+./build/darwin-arm/roles -profile <aws-profile> -clean                    # Tear down probe resources
+```
+
+## Architecture
+
+### Scanning Flow
+
+1. **`main.go`** — CLI flag parsing, delegates to `pkg/cmd`
+2. **`pkg/cmd/run.go`** — Orchestrates a scan: loads AWS configs across all org accounts/regions, builds ARN list from templates, runs scanner, outputs results
+3. **`pkg/arn/`** — Expands Go template role names (`{{.AccountId}}`, `{{.Region}}`) into concrete ARNs for each account/region combination
+4. **`pkg/scanner/main.go`** — Core scan loop. Two-phase approach: first scans "root ARNs" (`arn:aws:iam::<account>:root`) to check if accounts exist, then scans individual role ARNs only for confirmed accounts. Uses token-bucket rate limiting and concurrent plugin goroutines
+5. **`pkg/scanner/storage.go`** — JSON file cache at `~/.roles/<name>.json` with file locking. Caches ARN existence results to avoid rescanning. Use `-force` to bypass
+6. **`pkg/plugins/`** — Each plugin implements the `Plugin` interface and uses a different AWS service to probe principal existence
+
+### Plugin System
+
+All plugins implement `plugins.Plugin` (in `pkg/plugins/types.go`):
+
+```go
+type Plugin interface {
+    Name() string
+    Setup(ctx *utils.Context) error       // Creates AWS resources (only with -setup flag)
+    ScanArn(ctx *utils.Context, arn string) (bool, error)  // Probes if ARN exists
+    CleanUp(ctx *utils.Context) error     // Tears down resources (only with -clean flag)
+}
+```
+
+Plugins are registered in `pkg/cmd/main.go` via `LoadAllPlugins()`. Each plugin gets instantiated per-region with a configurable concurrency (thread count). The initializer must construct all resource ARNs deterministically — `Setup()` is only called once, not on every run.
+
+Current plugins: ECR Public, S3 Access Points, S3 Buckets, SNS Topics, SQS Queues.
+
+### Input Format
+
+Account and role lists are plain text files, one entry per line. Lines support `# comments` after the value. Role names use Go `text/template` syntax for parameterization. The `-roles` flag accepts comma-separated paths, and each path can be a file or directory of `.list` files.
+
+### Key Design Decisions
+
+- **Root-first scanning**: Checks account root ARN before scanning individual roles, avoiding wasted API calls against nonexistent accounts
+- **Plugin concurrency**: Each plugin instance runs in its own goroutine consuming from a shared input channel; the rate limiter is shared across all plugins
+- **Results are yielded via `iter.Seq2`** (Go 1.23 range-over-func) — callers iterate results as they arrive rather than waiting for completion

--- a/README.md
+++ b/README.md
@@ -68,6 +68,152 @@ However, a few things worth noting here:
 * This was an unoptimized test.
 * Depending on how rate limiting works, these rates may not be representative of a longer run.
 
+## IAM Permissions
+
+The scanner needs different permissions depending on the operation. Below are example IAM policies for each mode.
+
+### Scanning (normal run)
+
+This is the minimum policy needed for a regular scan (after setup has already been run once). If you're not using AWS Organizations, you can omit the `organizations:` and `sts:AssumeRole` permissions — the tool gracefully falls back to single-account mode.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Scan",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "account:ListRegions",
+                "sns:SetTopicAttributes",
+                "sqs:SetQueueAttributes",
+                "s3:PutBucketPolicy",
+                "s3:PutAccessPointPolicy",
+                "ecr-public:SetRepositoryPolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "OrgDiscovery",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:ListAccounts",
+                "organizations:ListTagsForResource",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### Setup (`-setup`)
+
+One-time resource creation. Includes all scanning permissions plus the ability to create the probe resources each plugin uses.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ScanAndSetup",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "account:ListRegions",
+                "sns:CreateTopic",
+                "sns:SetTopicAttributes",
+                "sqs:CreateQueue",
+                "sqs:SetQueueAttributes",
+                "s3:CreateBucket",
+                "s3:PutBucketPolicy",
+                "s3:CreateAccessPoint",
+                "s3:GetAccessPoint",
+                "s3:PutAccessPointPolicy",
+                "ecr-public:CreateRepository",
+                "ecr-public:SetRepositoryPolicy"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "OrgDiscovery",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:ListAccounts",
+                "organizations:ListTagsForResource",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### Cleanup (`-clean`)
+
+Tear down all probe resources created during setup.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Cleanup",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
+                "account:ListRegions",
+                "sns:DeleteTopic",
+                "sqs:DeleteQueue",
+                "s3:DeleteBucketPolicy",
+                "s3:DeleteBucket",
+                "s3:ListAccessPoints",
+                "s3:DeleteAccessPoint",
+                "ecr-public:DeleteRepository"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "OrgDiscovery",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:ListAccounts",
+                "organizations:ListTagsForResource",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+### Organization Setup (`-setup -org`)
+
+Only needed if you're using the optional multi-account org mode. This is in addition to the setup permissions above.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "OrgSetup",
+            "Effect": "Allow",
+            "Action": [
+                "organizations:CreateOrganization",
+                "organizations:DescribeOrganization",
+                "organizations:CreateAccount",
+                "organizations:DescribeCreateAccountStatus",
+                "account:EnableRegion"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+
+**Note:** The S3 access point permissions use the `s3:` prefix (not `s3control:`). AWS maps the S3 Control API actions to `s3:` IAM action names. Similarly, ECR Public actions use the `ecr-public:` prefix.
+
 ## Build
 
 ```

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -13,6 +13,14 @@ import (
 	"strings"
 )
 
+type scanRecord struct {
+	Arn       string `json:"arn"`
+	AccountID string `json:"account_id"`
+	RoleName  string `json:"role_name"`
+	Exists    bool   `json:"exists"`
+	Comment   string `json:"comment"`
+}
+
 func Run(ctx *utils.Context, opts Opts) error {
 	cfg, err := config.LoadDefaultConfig(ctx.Context,
 		config.WithRegion("us-east-1"),
@@ -58,29 +66,22 @@ func Run(ctx *utils.Context, opts Opts) error {
 
 	for principalArn, exists := range scan.ScanArns(ctx, lo.Keys(scanData)) {
 		if opts.Json {
-			rec := struct {
-				Arn       string `json:"arn"`
-				AccountID string `json:"account_id"`
-				RoleName  string `json:"role_name"`
-				Exists    bool   `json:"exists"`
-				Comment   string `json:"comment"`
-			}{
-				Arn:    principalArn,
-				Exists: exists,
-			}
+			rec := scanRecord{Arn: principalArn, Exists: exists}
 			if parsed, err := awsarn.Parse(principalArn); err == nil {
 				rec.AccountID = parsed.AccountID
-				resource := parsed.Resource
-				if idx := strings.Index(resource, "/"); idx >= 0 {
-					rec.RoleName = resource[idx+1:]
+				if _, name, ok := strings.Cut(parsed.Resource, "/"); ok {
+					rec.RoleName = name
 				} else {
-					rec.RoleName = resource
+					rec.RoleName = parsed.Resource
 				}
 			}
 			if info, ok := scanData[principalArn]; ok {
 				rec.Comment = info.Comment
 			}
-			line, _ := json.Marshal(rec)
+			line, err := json.Marshal(rec)
+			if err != nil {
+				return fmt.Errorf("marshaling record for %s: %w", principalArn, err)
+			}
 			fmt.Println(string(line))
 		} else if exists {
 			fmt.Println(principalArn, "#", scanData[principalArn].Comment)

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -17,7 +17,12 @@ import (
 func Setup(ctx *utils.Context, profile string, org bool) error {
 	ctx.Info.Printf("Running one-time account optimization")
 
-	cfg, err := config.LoadDefaultConfig(ctx.Context, config.WithRegion("us-east-1"), config.WithSharedConfigProfile(profile))
+	cfg, err := config.LoadDefaultConfig(ctx.Context,
+		config.WithRegion("us-east-1"),
+		config.WithSharedConfigProfile(profile),
+		config.WithRetryMode(aws.RetryModeAdaptive),
+		config.WithRetryMaxAttempts(10),
+	)
 	if err != nil {
 		return fmt.Errorf("loading config: %s", err)
 	}
@@ -42,6 +47,19 @@ func Setup(ctx *utils.Context, profile string, org bool) error {
 }
 
 func SetupAccounts(ctx *utils.Context, accounts map[string]utils.Account, cfg aws.Config, err error) error {
+	wg := sync.WaitGroup{}
+	for _, v := range accounts {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := utils.EnableAllRegions(ctx, v.Svc.Account); err != nil {
+				ctx.Error.Printf("enabling all regions: %s", err)
+			}
+		}()
+	}
+	ctx.Info.Printf("Enabling all regions, this can take a while...")
+	wg.Wait()
+
 	cfgs, err := utils.LoadConfigs(ctx, accounts)
 	if err != nil {
 		return fmt.Errorf("loading configs: %s", err)

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -42,22 +42,6 @@ func Setup(ctx *utils.Context, profile string, org bool) error {
 }
 
 func SetupAccounts(ctx *utils.Context, accounts map[string]utils.Account, cfg aws.Config, err error) error {
-	wg := sync.WaitGroup{}
-
-	// Run setup for each account
-	for _, v := range accounts {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			if err := utils.EnableAllRegions(ctx, v.Svc.Account); err != nil {
-				ctx.Error.Printf("enabling all regions: %s", err)
-			}
-		}()
-	}
-
-	wg.Wait()
-	ctx.Info.Printf("Enabling all regions, this can take a while...")
-
 	cfgs, err := utils.LoadConfigs(ctx, accounts)
 	if err != nil {
 		return fmt.Errorf("loading configs: %s", err)

--- a/pkg/scanner/main.go
+++ b/pkg/scanner/main.go
@@ -2,6 +2,8 @@ package scanner
 
 import (
 	"context"
+	"sync/atomic"
+
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/ryanjarv/roles/pkg/plugins"
 	"github.com/ryanjarv/roles/pkg/utils"
@@ -161,7 +163,7 @@ func scanWithPlugins(ctx *utils.Context, scanPlugins []plugins.Plugin, principal
 	input := make(chan string, queueSize)
 	results := make(chan Result, queueSize)
 
-	processed := 0
+	var processed int64
 	attempts := map[string]int{}
 	attemptsMux := sync.Mutex{}
 	workWg := sync.WaitGroup{}
@@ -184,7 +186,7 @@ func scanWithPlugins(ctx *utils.Context, scanPlugins []plugins.Plugin, principal
 					if attempt < maxScanAttempts {
 						ctx.Error.Printf("%s: scanning %s: %s (retrying %d/%d)", plugin.Name(), principalArn, err, attempt+1, maxScanAttempts)
 						workWg.Add(1)
-						input <- principalArn
+						go func() { input <- principalArn }()
 					} else {
 						ctx.Error.Printf("%s: scanning %s: %s (giving up after %d attempts)", plugin.Name(), principalArn, err, attempt)
 					}
@@ -197,7 +199,7 @@ func scanWithPlugins(ctx *utils.Context, scanPlugins []plugins.Plugin, principal
 				} else {
 					ctx.Debug.Printf("not found: %s", principalArn)
 				}
-				processed++
+				atomic.AddInt64(&processed, 1)
 
 				results <- Result{Arn: principalArn, Exists: exists}
 				workWg.Done()
@@ -229,7 +231,7 @@ func scanWithPlugins(ctx *utils.Context, scanPlugins []plugins.Plugin, principal
 }
 
 // LogStats logs stats every 5 seconds until the context is done.
-func LogStats(ctx *utils.Context, processed *int) context.CancelFunc {
+func LogStats(ctx *utils.Context, processed *int64) context.CancelFunc {
 	start := time.Now()
 
 	ctx, cancelFunc := ctx.WithCancel()
@@ -240,9 +242,10 @@ func LogStats(ctx *utils.Context, processed *int) context.CancelFunc {
 			case <-ctx.Done():
 				break
 			case <-time.After(5 * time.Second):
+				n := atomic.LoadInt64(processed)
 				elapsed := time.Now().Sub(start)
-				perSecond := float64(*processed) / elapsed.Seconds()
-				ctx.Info.Printf("processed %d in %.1f seconds: %.1f/second", *processed, elapsed.Seconds(), perSecond)
+				perSecond := float64(n) / elapsed.Seconds()
+				ctx.Info.Printf("processed %d in %.1f seconds: %.1f/second", n, elapsed.Seconds(), perSecond)
 			}
 		}
 	}()

--- a/pkg/scanner/main.go
+++ b/pkg/scanner/main.go
@@ -185,8 +185,10 @@ func scanWithPlugins(ctx *utils.Context, scanPlugins []plugins.Plugin, principal
 
 					if attempt < maxScanAttempts {
 						ctx.Error.Printf("%s: scanning %s: %s (retrying %d/%d)", plugin.Name(), principalArn, err, attempt+1, maxScanAttempts)
-						workWg.Add(1)
-						go func() { input <- principalArn }()
+						// Must be a goroutine: if all workers are retrying and the input buffer is full,
+					// a direct send blocks forever since no worker can drain input while blocked.
+					workWg.Add(1)
+					go func() { input <- principalArn }()
 					} else {
 						ctx.Error.Printf("%s: scanning %s: %s (giving up after %d attempts)", plugin.Name(), principalArn, err, attempt)
 					}

--- a/pkg/scanner/scan_test.go
+++ b/pkg/scanner/scan_test.go
@@ -3,10 +3,12 @@ package scanner
 import (
 	"context"
 	"fmt"
+	"sync"
+	"testing"
+
 	"github.com/ryanjarv/roles/pkg/plugins"
 	"github.com/ryanjarv/roles/pkg/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 // mockPlugin implements plugins.Plugin for testing scanWithPlugins.
@@ -109,6 +111,48 @@ func TestScanWithPlugins_PersistentErrorsAreNotEmitted(t *testing.T) {
 
 	assert.Equal(t, maxScanAttempts, attempts)
 	assert.Empty(t, got, "persistent errors should not emit a false-negative result")
+}
+
+// TestScanWithPlugins_DeadlockUnderRetryPressure exercises the scenario where
+// more retries than channel buffer slots are in-flight simultaneously. Previously
+// workers would block on input<-arn with a full buffer, causing a deadlock.
+func TestScanWithPlugins_DeadlockUnderRetryPressure(t *testing.T) {
+	ctx := utils.NewContext(context.Background())
+
+	// Generate more ARNs than the buffer size (10 * 1 plugin = 10), all of
+	// which will error once then succeed. This ensures retry pressure exceeds
+	// the buffer and would deadlock without the goroutine fix.
+	const arnCount = 30
+	arns := make([]string, arnCount)
+	for i := range arns {
+		arns[i] = fmt.Sprintf("arn:aws:iam::111111111111:role/Role%d", i)
+	}
+
+	attempts := map[string]int{}
+	var mu sync.Mutex
+
+	plugin := &mockPlugin{
+		name: "pressure-plugin",
+		scanFunc: func(arn string) (bool, error) {
+			mu.Lock()
+			attempts[arn]++
+			n := attempts[arn]
+			mu.Unlock()
+			if n == 1 {
+				return false, fmt.Errorf("transient error")
+			}
+			return true, nil
+		},
+	}
+
+	results := scanWithPlugins(ctx, []plugins.Plugin{plugin}, arns, unlimitedBucket())
+
+	got := map[string]bool{}
+	for r := range results {
+		got[r.Arn] = r.Exists
+	}
+
+	assert.Len(t, got, arnCount, "all ARNs must produce a result")
 }
 
 // TestScanWithPlugins_AllResultsReturned verifies every ARN produces a result

--- a/pkg/utils/aws.go
+++ b/pkg/utils/aws.go
@@ -1,7 +1,6 @@
 package utils
 
 import (
-	"errors"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/account"
@@ -102,22 +101,11 @@ func EnableAllRegions(ctx *Context, svc *account.Client) error {
 		}
 
 		for _, region := range resp.Regions {
-			for {
-				ctx.Info.Printf("Opting in to region %s", *region.RegionName)
-
-				var toManyReqs *types.TooManyRequestsException
-
-				if _, err := svc.EnableRegion(ctx, &account.EnableRegionInput{
-					RegionName: region.RegionName,
-				}); errors.As(err, &toManyReqs) {
-					ctx.Info.Printf("Too many requests, sleeping for 10 seconds")
-					time.Sleep(10 * time.Second)
-					continue
-				} else if err != nil {
-					return fmt.Errorf("enabling region %s: %s", *region.RegionName, err)
-				} else {
-					break
-				}
+			ctx.Info.Printf("Opting in to region %s", *region.RegionName)
+			if _, err := svc.EnableRegion(ctx, &account.EnableRegionInput{
+				RegionName: region.RegionName,
+			}); err != nil {
+				return fmt.Errorf("enabling region %s: %s", *region.RegionName, err)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **Emit results for errored ARNs** — previously plugin errors were silently dropped, causing false negatives in scan output
- **Retry errored ARN scans** — transient AWS errors are retried up to 3 times (`maxScanAttempts`) with per-attempt logging; ARNs that exhaust retries are logged but not emitted as false negatives
- **Add `-json` flag** — JSONL output mode emitting structured records with `arn`, `account_id`, `role_name`, `exists`, and `comment` fields for every scanned ARN
- **Fix deadlock and data race** — `processed` counter changed to `atomic.Int64`; plugin goroutine closure now captures `plugin` by value; `workWg` tracks in-flight work including retries; retry sends use a goroutine to avoid blocking on a full buffer
- **Docs** — add `CLAUDE.md`, IAM permissions guide in README, remove dead region-enabling loop from `SetupAccounts`

## Test plan

- [x] `go test ./pkg/scanner/` — new tests cover retry-on-transient-error, persistent-error-not-emitted, deadlock-under-retry-pressure, and normal multi-plugin path
- [x] `go test -race ./pkg/scanner/` — verify no data races
- [ ] Manual scan with `-json` flag produces one JSONL record per ARN
- [ ] Manual scan without `-json` still prints only existing ARNs as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)