### PR TITLE
[codex] add principals input support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+`main.go` is the CLI entrypoint. Core code lives under `pkg/`: `pkg/cmd` handles CLI actions such as setup, cleanup, and scan execution; `pkg/scanner` contains the scan pipeline and storage logic; `pkg/plugins` holds AWS service probes; `pkg/utils` and `pkg/arn` provide shared helpers. Helper scripts for account and principal list generation live in `scripts/`. Compiled binaries are written to `build/` by the Makefile.
+
+## Build, Test, and Development Commands
+Use `make build` to produce the default binaries in `build/darwin-arm/roles` and `build/linux-arm/roles`. Use `go test ./...` for the full test suite across all packages. Run the CLI locally with `go run . -help`, `go run . -profile scanner -account-list ./accounts.list -roles ./roles.list`, or `go run . -profile scanner -account-list ./accounts.list -principals ./principals.list`. Use `go test ./pkg/scanner -run TestScanWithPlugins` when iterating on scanner behavior.
+
+## Coding Style & Naming Conventions
+Follow standard Go formatting: tabs for indentation, `gofmt` for layout, and grouped imports. Keep packages focused and small; new AWS probes should follow the existing plugin shape in `pkg/plugins` with clear `Setup`, `ScanArn`, and `CleanUp` behavior. Use exported CamelCase names only when cross-package access is required; keep internal helpers lowercase. Preserve the input contract: `-roles` takes bare role names, while `-principals` takes explicit `role/...` or `user/...` entries.
+
+## Testing Guidelines
+Write table-driven tests where inputs vary, and keep tests next to the package they cover as `*_test.go`. Current coverage centers on `pkg/scanner`, `pkg/plugins`, `pkg/cmd`, and `pkg/utils`; extend those patterns instead of creating ad hoc harnesses. Run `go test ./...` before opening a PR. Add focused regression tests for concurrency, retry, and region-specific plugin behavior when fixing scanner or plugin bugs.
+
+## Commit & Pull Request Guidelines
+Recent history uses short imperative subjects with prefixes like `fix:` and `docs:`. Keep commit messages specific, for example `fix: retry errored ARNs without deadlock`. PRs should explain behavioral impact, call out any AWS permissions or scanning changes, and link the related issue if one exists. Include command output or sample CLI usage when changing operator-facing behavior.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-Go CLI tool for unauthenticated enumeration of AWS IAM Role ARNs. It probes whether specific IAM role ARNs exist in target AWS accounts by abusing resource policy validation on AWS services (SNS, SQS, S3, ECR Public, S3 Access Points). Each service acts as a "plugin" — it creates a resource, sets a policy referencing a candidate principal ARN, and checks whether AWS accepts or rejects the principal.
+Go CLI tool for unauthenticated enumeration of AWS IAM principal ARNs. It probes whether specific IAM role or user ARNs exist in target AWS accounts by abusing resource policy validation on AWS services (SNS, SQS, S3, ECR Public, S3 Access Points). Each service acts as a "plugin" — it creates a resource, sets a policy referencing a candidate principal ARN, and checks whether AWS accepts or rejects the principal.
 
 This tool is part of the larger `saas-map` project (see parent directory's CLAUDE.md) and provides the scanning engine that discovers which SaaS provider roles exist in a given AWS account.
 
@@ -22,8 +22,9 @@ go test -run TestName ./pkg/  # Run a single test
 
 ```bash
 ./build/darwin-arm/roles -profile <aws-profile> -setup                    # One-time setup (creates probe resources)
-./build/darwin-arm/roles -profile <aws-profile> -account-list accounts.list -roles roles.list  # Scan
-./build/darwin-arm/roles -json -profile <aws-profile> -account-list accounts.list -roles roles.list  # JSONL output
+./build/darwin-arm/roles -profile <aws-profile> -account-list accounts.list -roles roles.list  # Scan legacy role lists
+./build/darwin-arm/roles -profile <aws-profile> -account-list accounts.list -principals principals.list  # Scan explicit role/... and user/... principals
+./build/darwin-arm/roles -json -profile <aws-profile> -account-list accounts.list -principals principals.list  # JSONL output
 ./build/darwin-arm/roles -profile <aws-profile> -clean                    # Tear down probe resources
 ```
 
@@ -32,9 +33,9 @@ go test -run TestName ./pkg/  # Run a single test
 ### Scanning Flow
 
 1. **`main.go`** — CLI flag parsing, delegates to `pkg/cmd`
-2. **`pkg/cmd/run.go`** — Orchestrates a scan: loads AWS configs across all org accounts/regions, builds ARN list from templates, runs scanner, outputs results
-3. **`pkg/arn/`** — Expands Go template role names (`{{.AccountId}}`, `{{.Region}}`) into concrete ARNs for each account/region combination
-4. **`pkg/scanner/main.go`** — Core scan loop. Two-phase approach: first scans "root ARNs" (`arn:aws:iam::<account>:root`) to check if accounts exist, then scans individual role ARNs only for confirmed accounts. Uses token-bucket rate limiting and concurrent plugin goroutines
+2. **`pkg/cmd/run.go`** — Orchestrates a scan: loads AWS configs across all org accounts/regions, builds principal ARN lists from templates, runs scanner, outputs results
+3. **`pkg/arn/`** — Expands Go template principal names (`{{.AccountId}}`, `{{.Region}}`) into concrete ARNs for each account/region combination. `-roles` still prepends `role/`, while `-principals` expects explicit `role/...` or `user/...` entries.
+4. **`pkg/scanner/main.go`** — Core scan loop. Two-phase approach: first scans "root ARNs" (`arn:aws:iam::<account>:root`) to check if accounts exist, then scans individual principal ARNs only for confirmed accounts. Uses token-bucket rate limiting and concurrent plugin goroutines
 5. **`pkg/scanner/storage.go`** — JSON file cache at `~/.roles/<name>.json` with file locking. Caches ARN existence results to avoid rescanning. Use `-force` to bypass
 6. **`pkg/plugins/`** — Each plugin implements the `Plugin` interface and uses a different AWS service to probe principal existence
 
@@ -57,10 +58,10 @@ Current plugins: ECR Public, S3 Access Points, S3 Buckets, SNS Topics, SQS Queue
 
 ### Input Format
 
-Account and role lists are plain text files, one entry per line. Lines support `# comments` after the value. Role names use Go `text/template` syntax for parameterization. The `-roles` flag accepts comma-separated paths, and each path can be a file or directory of `.list` files.
+Account and principal lists are plain text files, one entry per line. Lines support `# comments` after the value. Templates use Go `text/template` syntax for parameterization. The `-roles` flag accepts bare role names and prepends `role/`; the `-principals` flag accepts explicit `role/...` or `user/...` entries. Both flags accept comma-separated paths, and each path can be a file or directory of `.list` files.
 
 ### Key Design Decisions
 
-- **Root-first scanning**: Checks account root ARN before scanning individual roles, avoiding wasted API calls against nonexistent accounts
+- **Root-first scanning**: Checks account root ARN before scanning individual principals, avoiding wasted API calls against nonexistent accounts
 - **Plugin concurrency**: Each plugin instance runs in its own goroutine consuming from a shared input channel; the rate limiter is shared across all plugins
 - **Results are yielded via `iter.Seq2`** (Go 1.23 range-over-func) — callers iterate results as they arrive rather than waiting for completion

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Roles
 
-Unauthenticated enumeration of AWS IAM Roles.
+Unauthenticated enumeration of AWS IAM principals.
 
 By default, this tool is rate limited to 10 roles/second, this can be increased up to 50 by passing the `-rate` flag.
 
@@ -10,11 +10,12 @@ By default, this tool is rate limited to 10 roles/second, this can be increased 
 make build
 ./build/darwin-arm/roles -profile scanner -setup
 ./build/darwin-arm/roles -profile scanner -account-list ./path/to/accounts.list -roles ~/path/to/role_names.list
+./build/darwin-arm/roles -profile scanner -account-list ./path/to/accounts.list -principals ~/path/to/principals.list
 ```
 
 ## Lists
 
-The account and role names lists are just plain lists with one value per line with an optional comment.
+The account and principal name lists are plain text files with one value per line and an optional comment.
 
 White space is trimmed from the beginning and end of the value before it is used.
 
@@ -30,6 +31,19 @@ For example:
 StaticRoleName # Default X role # Found at ...
 DynamicRoleName-{{.Region}}-{{.AccountId}} # Software A # Found at ...
 path/DynamicRoleName-{{.Region}}-{{.AccountId}} # Software B # Found at ...
+```
+
+### Principals List
+
+* The `-principals` flag accepts the same file and directory inputs as `-roles`.
+* Each entry must include the IAM principal prefix, for example `role/Admin` or `user/alice`.
+* Principal names can also use `{{.AccountId}}` and `{{.Region}}` templates.
+
+For example:
+
+```
+role/Admin # Static role
+user/deploy-{{.Region}} # Regional user
 ```
 
 ## Organization Setup

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ func main() {
 	flag.StringVar(&opts.Profile, "profile", "", "AWS profile to use for scanning")
 	flag.StringVar(&opts.Name, "name", "default", "Name of the scan")
 	flag.StringVar(&opts.RolesPath, "roles", "", "Additional role names")
+	flag.StringVar(&opts.PrincipalsPath, "principals", "", "Additional principal names prefixed with role/ or user/")
 	flag.StringVar(&opts.AccountsPath, "account-list", "", "Path to a file containing account IDs")
 	flag.StringVar(&opts.AccountsStr, "accounts", "", "Path to a file containing account IDs")
 	flag.BoolVar(&opts.Force, "force", false, "Force rescan")

--- a/pkg/arn/main.go
+++ b/pkg/arn/main.go
@@ -9,11 +9,12 @@ import (
 )
 
 type GetArnsInput struct {
-	RolePaths    []string
-	Regions      map[string]utils.Info
-	ForceScan    bool
-	AccountsStr  string
-	AccountsPath string
+	RolePaths      []string
+	PrincipalPaths []string
+	Regions        map[string]utils.Info
+	ForceScan      bool
+	AccountsStr    string
+	AccountsPath   string
 }
 
 func GetArns(ctx *utils.Context, input *GetArnsInput) (map[string]utils.Info, error) {
@@ -37,9 +38,18 @@ func GetArns(ctx *utils.Context, input *GetArnsInput) (map[string]utils.Info, er
 		accounts[value] = utils.Info{}
 	}
 
-	roles, err := utils.GetInput(input.RolePaths...)
+	roles, err := getRoleInputs(input.RolePaths)
 	if err != nil {
 		return nil, fmt.Errorf("getting allRoles: %s", err)
+	}
+
+	principals, err := getPrincipalInputs(input.PrincipalPaths)
+	if err != nil {
+		return nil, fmt.Errorf("getting allPrincipals: %s", err)
+	}
+
+	for name, info := range principals {
+		roles[name] = info
 	}
 
 	result := map[string]utils.Info{}
@@ -74,15 +84,44 @@ type roleData struct {
 	Region    string
 }
 
+func getRoleInputs(paths []string) (map[string]utils.Info, error) {
+	roles, err := utils.GetInput(paths...)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[string]utils.Info{}
+	for role, info := range roles {
+		result["role/"+role] = info
+	}
+
+	return result, nil
+}
+
+func getPrincipalInputs(paths []string) (map[string]utils.Info, error) {
+	principals, err := utils.GetInput(paths...)
+	if err != nil {
+		return nil, err
+	}
+
+	for principal := range principals {
+		if !strings.HasPrefix(principal, "role/") && !strings.HasPrefix(principal, "user/") {
+			return nil, fmt.Errorf("principal %q must start with role/ or user/", principal)
+		}
+	}
+
+	return principals, nil
+}
+
 // GetArn returns a list of ARNs based on the given template, account, and region
 //
 // Example:
 //
-//	cdk-hnb659fds-deploy-role-{{AccountId}}-{{region}}" -> [
+//	role/cdk-hnb659fds-deploy-role-{{AccountId}}-{{region}}" -> [
 //			"arn:aws:iam::123456789012:role/cdk-hnb659fds-deploy-role-123456789012-us-west-2"
 //	]
-func GetArn(role string, account string, region string) (string, error) {
-	tmpl, err := template.New(role).Parse(role)
+func GetArn(principal string, account string, region string) (string, error) {
+	tmpl, err := template.New(principal).Parse(principal)
 	if err != nil {
 		return "", err
 	}
@@ -94,5 +133,5 @@ func GetArn(role string, account string, region string) (string, error) {
 
 	var buf bytes.Buffer
 	err = tmpl.Execute(&buf, data)
-	return fmt.Sprintf("arn:aws:iam::%s:role/%s", account, buf.String()), err
+	return fmt.Sprintf("arn:aws:iam::%s:%s", account, buf.String()), err
 }

--- a/pkg/arn/main_test.go
+++ b/pkg/arn/main_test.go
@@ -1,0 +1,67 @@
+package arn
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ryanjarv/roles/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetArn(t *testing.T) {
+	got, err := GetArn("role/cdk-hnb659fds-deploy-role-{{.AccountId}}-{{.Region}}", "123456789012", "us-west-2")
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::123456789012:role/cdk-hnb659fds-deploy-role-123456789012-us-west-2", got)
+
+	got, err = GetArn("user/alice-{{.Region}}", "123456789012", "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, "arn:aws:iam::123456789012:user/alice-us-east-1", got)
+}
+
+func TestGetArns_MergesRolesAndPrincipals(t *testing.T) {
+	ctx := utils.NewContext(context.Background())
+	dir := t.TempDir()
+	rolesPath := filepath.Join(dir, "roles.list")
+	principalsPath := filepath.Join(dir, "principals.list")
+
+	require.NoError(t, os.WriteFile(rolesPath, []byte("Admin # role comment\n"), 0o600))
+	require.NoError(t, os.WriteFile(principalsPath, []byte("user/alice-{{.Region}} # user comment\n"), 0o600))
+
+	got, err := GetArns(ctx, &GetArnsInput{
+		AccountsStr:    "123456789012",
+		RolePaths:      []string{rolesPath},
+		PrincipalPaths: []string{principalsPath},
+		Regions: map[string]utils.Info{
+			"us-east-1": {},
+		},
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, got, "arn:aws:iam::123456789012:root")
+	assert.Equal(t, " -  role comment", got["arn:aws:iam::123456789012:role/Admin"].Comment)
+	assert.Equal(t, " -  user comment", got["arn:aws:iam::123456789012:user/alice-us-east-1"].Comment)
+}
+
+func TestGetRoleInputs_AddsRolePrefix(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/roles.list"
+	require.NoError(t, os.WriteFile(path, []byte("Admin\npath/Operator # comment\n"), 0o600))
+
+	got, err := getRoleInputs([]string{path})
+	require.NoError(t, err)
+	assert.Equal(t, utils.Info{}, got["role/Admin"])
+	assert.Equal(t, " comment", got["role/path/Operator"].Comment)
+}
+
+func TestGetPrincipalInputs_RejectsMissingPrefix(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "principals.list")
+	require.NoError(t, os.WriteFile(path, []byte("Admin\n"), 0o600))
+
+	_, err := getPrincipalInputs([]string{path})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must start with role/ or user/")
+}

--- a/pkg/cmd/main.go
+++ b/pkg/cmd/main.go
@@ -10,18 +10,19 @@ import (
 var regionsList string
 
 type Opts struct {
-	Debug        bool
-	Setup        bool
-	Org          bool
-	Profile      string
-	Name         string
-	RolesPath    string
-	AccountsPath string
-	AccountsStr  string
-	Force        bool
-	Clean        bool
-	RateLimit    int
-	Json         bool
+	Debug          bool
+	Setup          bool
+	Org            bool
+	Profile        string
+	Name           string
+	RolesPath      string
+	PrincipalsPath string
+	AccountsPath   string
+	AccountsStr    string
+	Force          bool
+	Clean          bool
+	RateLimit      int
+	Json           bool
 }
 
 // LoadAllPlugins loads all enabled plugins.

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -14,11 +14,13 @@ import (
 )
 
 type scanRecord struct {
-	Arn       string `json:"arn"`
-	AccountID string `json:"account_id"`
-	RoleName  string `json:"role_name"`
-	Exists    bool   `json:"exists"`
-	Comment   string `json:"comment"`
+	Arn           string `json:"arn"`
+	AccountID     string `json:"account_id"`
+	RoleName      string `json:"role_name"`
+	PrincipalName string `json:"principal_name"`
+	PrincipalType string `json:"principal_type"`
+	Exists        bool   `json:"exists"`
+	Comment       string `json:"comment"`
 }
 
 func Run(ctx *utils.Context, opts Opts) error {
@@ -55,10 +57,11 @@ func Run(ctx *utils.Context, opts Opts) error {
 	})
 
 	scanData, err := arn.GetArns(ctx, &arn.GetArnsInput{
-		AccountsStr:  opts.AccountsStr,
-		AccountsPath: opts.AccountsPath,
-		RolePaths:    strings.Split(opts.RolesPath, ","),
-		Regions:      utils.GetInputFromPath(regionsList),
+		AccountsStr:    opts.AccountsStr,
+		AccountsPath:   opts.AccountsPath,
+		RolePaths:      splitPaths(opts.RolesPath),
+		PrincipalPaths: splitPaths(opts.PrincipalsPath),
+		Regions:        utils.GetInputFromPath(regionsList),
 	})
 	if err != nil {
 		return fmt.Errorf("getting scanData: %s", err)
@@ -69,9 +72,12 @@ func Run(ctx *utils.Context, opts Opts) error {
 			rec := scanRecord{Arn: principalArn, Exists: exists}
 			if parsed, err := awsarn.Parse(principalArn); err == nil {
 				rec.AccountID = parsed.AccountID
-				if _, name, ok := strings.Cut(parsed.Resource, "/"); ok {
+				if kind, name, ok := strings.Cut(parsed.Resource, "/"); ok {
+					rec.PrincipalType = kind
+					rec.PrincipalName = name
 					rec.RoleName = name
 				} else {
+					rec.PrincipalName = parsed.Resource
 					rec.RoleName = parsed.Resource
 				}
 			}
@@ -93,4 +99,16 @@ func Run(ctx *utils.Context, opts Opts) error {
 	}
 
 	return nil
+}
+
+func splitPaths(value string) []string {
+	var result []string
+	for _, path := range strings.Split(value, ",") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		result = append(result, path)
+	}
+	return result
 }


### PR DESCRIPTION
## Summary

Add a new `-principals` flag that accepts explicit IAM principal names prefixed with `role/` or `user/`, while keeping the existing `-roles` flag backward compatible.

## What Changed

- added `-principals` CLI support alongside the existing `-roles` flag
- updated ARN generation to stop hardcoding the `role/` resource prefix
- kept `-roles` behavior by prepending `role/` to legacy role-name inputs
- validated that `-principals` entries must start with `role/` or `user/`
- extended JSON output with `principal_type` and `principal_name` while retaining `role_name` for compatibility
- added ARN package tests for mixed role/user expansion and invalid principal input
- updated README, CLAUDE.md, and AGENTS.md to document the new input format

## Why

The scanner path already operates on arbitrary IAM principal ARNs. The hardcoded `role/` prefix in candidate generation was the main blocker for scanning IAM users. This change removes that assumption without breaking existing `-roles` workflows.

## Validation

- `go test ./...`
